### PR TITLE
Revert "rename delete-slots to deleted-slots"

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ kubectl scale --resource-version=$RESOURCE_VERSION --replicas=3 statefulsets.pin
 
 ### scale in at arbitrary position
 
-We should set `deleted-slots` annotations and decrement `spec.replicas` at the
+We should set `delete-slots` annotations and decrement `spec.replicas` at the
 same time.
 
 ```

--- a/examples/scale-in-statefulset.yaml
+++ b/examples/scale-in-statefulset.yaml
@@ -3,7 +3,7 @@ kind: StatefulSet
 metadata:
   name: web
   annotations:
-    deleted-slots: '[1]'
+    delete-slots: '[1]'
 spec:
   selector:
     matchLabels:

--- a/pkg/apis/apps/v1alpha1/helper/helper.go
+++ b/pkg/apis/apps/v1alpha1/helper/helper.go
@@ -24,16 +24,16 @@ import (
 )
 
 const (
-	deletedSlotsAnn = "deleted-slots"
+	deleteSlotsAnn = "delete-slots"
 )
 
-func GetDeletedSlots(set metav1.Object) (deletedSlots sets.Int) {
-	deletedSlots = sets.NewInt()
+func GetDeleteSlots(set metav1.Object) (deleteSlots sets.Int) {
+	deleteSlots = sets.NewInt()
 	annotations := set.GetAnnotations()
 	if annotations == nil {
 		return
 	}
-	value, ok := annotations[deletedSlotsAnn]
+	value, ok := annotations[deleteSlotsAnn]
 	if !ok {
 		return
 	}
@@ -42,45 +42,45 @@ func GetDeletedSlots(set metav1.Object) (deletedSlots sets.Int) {
 	if err != nil {
 		return
 	}
-	deletedSlots.Insert(slice...)
+	deleteSlots.Insert(slice...)
 	return
 }
 
-func SetDeletedSlots(set metav1.Object, deletedSlots sets.Int) (err error) {
+func SetDeleteSlots(set metav1.Object, deleteSlots sets.Int) (err error) {
 	annotations := set.GetAnnotations()
-	if deletedSlots == nil || deletedSlots.Len() == 0 {
+	if deleteSlots == nil || deleteSlots.Len() == 0 {
 		// clear
-		delete(annotations, deletedSlotsAnn)
+		delete(annotations, deleteSlotsAnn)
 	} else {
 		// set
-		b, err := json.Marshal(deletedSlots.List())
+		b, err := json.Marshal(deleteSlots.List())
 		if err != nil {
 			return err
 		}
 		if annotations == nil {
 			annotations = make(map[string]string)
 		}
-		annotations[deletedSlotsAnn] = string(b)
+		annotations[deleteSlotsAnn] = string(b)
 	}
 	set.SetAnnotations(annotations)
 	return
 }
 
-func AddDeletedSlots(set metav1.Object, deletedSlots sets.Int) (err error) {
-	currentDeletedSlots := GetDeletedSlots(set)
-	return SetDeletedSlots(set, currentDeletedSlots.Union(deletedSlots))
+func AddDeleteSlots(set metav1.Object, deleteSlots sets.Int) (err error) {
+	currentDeleteSlots := GetDeleteSlots(set)
+	return SetDeleteSlots(set, currentDeleteSlots.Union(deleteSlots))
 }
 
-// GetMaxReplicaCountAndDeletedSlots returns the max replica count and delete
+// GetMaxReplicaCountAndDeleteSlots returns the max replica count and delete
 // slots. The desired slots of this stateful set will be [0, replicaCount) - [delete slots].
-func GetMaxReplicaCountAndDeletedSlots(replicas int, deletedSlots sets.Int) (int, sets.Int) {
+func GetMaxReplicaCountAndDeleteSlots(replicas int, deleteSlots sets.Int) (int, sets.Int) {
 	replicaCount := replicas
-	for _, deleteSlot := range deletedSlots.List() {
+	for _, deleteSlot := range deleteSlots.List() {
 		if deleteSlot < replicaCount {
 			replicaCount++
 		} else {
-			deletedSlots.Delete(deleteSlot)
+			deleteSlots.Delete(deleteSlot)
 		}
 	}
-	return replicaCount, deletedSlots
+	return replicaCount, deleteSlots
 }

--- a/pkg/apis/apps/v1alpha1/helper/helper_test.go
+++ b/pkg/apis/apps/v1alpha1/helper/helper_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func TestGetDeletedSlots(t *testing.T) {
+func TestGetDeleteSlots(t *testing.T) {
 	tests := []struct {
 		name string
 		sts  apps.StatefulSet
@@ -43,7 +43,7 @@ func TestGetDeletedSlots(t *testing.T) {
 			sts: apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						deletedSlotsAnn: "",
+						deleteSlotsAnn: "",
 					},
 				},
 			},
@@ -54,7 +54,7 @@ func TestGetDeletedSlots(t *testing.T) {
 			sts: apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						deletedSlotsAnn: "invalid",
+						deleteSlotsAnn: "invalid",
 					},
 				},
 			},
@@ -65,7 +65,7 @@ func TestGetDeletedSlots(t *testing.T) {
 			sts: apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						deletedSlotsAnn: "[1]",
+						deleteSlotsAnn: "[1]",
 					},
 				},
 			},
@@ -76,7 +76,7 @@ func TestGetDeletedSlots(t *testing.T) {
 			sts: apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						deletedSlotsAnn: "[1, 2, 3]",
+						deleteSlotsAnn: "[1, 2, 3]",
 					},
 				},
 			},
@@ -87,7 +87,7 @@ func TestGetDeletedSlots(t *testing.T) {
 			sts: apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						deletedSlotsAnn: "[1, 2, 3, 3]",
+						deleteSlotsAnn: "[1, 2, 3, 3]",
 					},
 				},
 			},
@@ -97,15 +97,15 @@ func TestGetDeletedSlots(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetDeletedSlots(&tt.sts)
+			got := GetDeleteSlots(&tt.sts)
 			if !got.Equal(tt.want) {
-				t.Errorf("GetDeletedSlots want %v got %v", tt.want, got)
+				t.Errorf("GetDeleteSlots want %v got %v", tt.want, got)
 			}
 		})
 	}
 }
 
-func TestSetDeletedSlots(t *testing.T) {
+func TestSetDeleteSlots(t *testing.T) {
 	tests := []struct {
 		name string
 		sts  apps.StatefulSet
@@ -117,7 +117,7 @@ func TestSetDeletedSlots(t *testing.T) {
 			sts: apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						deletedSlotsAnn: "[1]",
+						deleteSlotsAnn: "[1]",
 					},
 				},
 			},
@@ -133,7 +133,7 @@ func TestSetDeletedSlots(t *testing.T) {
 			sts: apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						deletedSlotsAnn: "[1]",
+						deleteSlotsAnn: "[1]",
 					},
 				},
 			},
@@ -153,7 +153,7 @@ func TestSetDeletedSlots(t *testing.T) {
 			want: apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						deletedSlotsAnn: "[3]",
+						deleteSlotsAnn: "[3]",
 					},
 				},
 			},
@@ -167,7 +167,7 @@ func TestSetDeletedSlots(t *testing.T) {
 			want: apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						deletedSlotsAnn: "[1,3,4]",
+						deleteSlotsAnn: "[1,3,4]",
 					},
 				},
 			},
@@ -176,7 +176,7 @@ func TestSetDeletedSlots(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_ = SetDeletedSlots(&tt.sts, tt.set)
+			_ = SetDeleteSlots(&tt.sts, tt.set)
 			if diff := cmp.Diff(tt.want, tt.sts); diff != "" {
 				t.Errorf("unexpected result (-want, +got): %s", diff)
 			}

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -279,12 +279,12 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 	*status.CollisionCount = collisionCount
 
 	// desired replica slots: [0, replicaCount) - [delete slots]
-	deletedSlots := helper.GetDeletedSlots(set)
-	replicaCount, deletedSlots := helper.GetMaxReplicaCountAndDeletedSlots(int(*set.Spec.Replicas), deletedSlots)
+	deleteSlots := helper.GetDeleteSlots(set)
+	replicaCount, deleteSlots := helper.GetMaxReplicaCountAndDeleteSlots(int(*set.Spec.Replicas), deleteSlots)
 
-	// slice that will contain all Pods such that 0 <= getOrdinal(pod) < set.Spec.Replicas and not in deletedSlots
+	// slice that will contain all Pods such that 0 <= getOrdinal(pod) < set.Spec.Replicas and not in deleteSlots
 	replicas := make([]*v1.Pod, replicaCount)
-	// slice that will contain all Pods such that set.Spec.Replicas <= getOrdinal(pod) or exist in deletedSlots
+	// slice that will contain all Pods such that set.Spec.Replicas <= getOrdinal(pod) or exist in deleteSlots
 	condemned := make([]*v1.Pod, 0, len(pods))
 	unhealthy := 0
 	firstUnhealthyOrdinal := math.MaxInt32
@@ -309,21 +309,21 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 			}
 		}
 
-		if ord := getOrdinal(pods[i]); 0 <= ord && ord < replicaCount && !deletedSlots.Has(ord) {
+		if ord := getOrdinal(pods[i]); 0 <= ord && ord < replicaCount && !deleteSlots.Has(ord) {
 			// if the ordinal of the pod is within the range of the current number of replicas,
 			// insert it at the indirection of its ordinal
 			replicas[ord] = pods[i]
 
-		} else if ord >= replicaCount || deletedSlots.Has(ord) {
+		} else if ord >= replicaCount || deleteSlots.Has(ord) {
 			// if the ordinal is greater than the number of replicas add it to the condemned list
 			condemned = append(condemned, pods[i])
 		}
 		// If the ordinal could not be parsed (ord < 0), ignore the Pod.
 	}
 
-	// for any empty indices in the sequence [0,set.Spec.Replicas) and do not exist in deletedSlots create a new Pod at the correct revision
+	// for any empty indices in the sequence [0,set.Spec.Replicas) and do not exist in deleteSlots create a new Pod at the correct revision
 	for ord := 0; ord < replicaCount; ord++ {
-		if deletedSlots.Has(ord) {
+		if deleteSlots.Has(ord) {
 			continue
 		}
 		if replicas[ord] == nil {

--- a/test/integration/statefulset/statefulset_delete_slots_test.go
+++ b/test/integration/statefulset/statefulset_delete_slots_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/klog"
 )
 
-func TestDeletedSlots(t *testing.T) {
+func TestDeleteSlots(t *testing.T) {
 	closeFn, rm, informers, c, appsinformers, pcc := scSetup(t)
 	defer closeFn()
 	ns := integrationutil.CreateTestingNamespace("test-spec-replicas-change", c, t)
@@ -55,15 +55,15 @@ func TestDeletedSlots(t *testing.T) {
 	checkPodIdentifiers(t, c, sts, 0, 2)
 
 	t.Logf(fmt.Sprintf("scale to replicas %d with delete slots %v", 0, []int{1}))
-	scaleSTSWithDeletedSlots(t, pcc, sts, 0, sets.NewInt(1))
+	scaleSTSWithDeleteSlots(t, pcc, sts, 0, sets.NewInt(1))
 	checkPodIdentifiers(t, c, sts)
 
 	t.Logf(fmt.Sprintf("scale to replicas %d with delete slots %v", 4, []int{}))
-	scaleSTSWithDeletedSlots(t, pcc, sts, 4, sets.NewInt())
+	scaleSTSWithDeleteSlots(t, pcc, sts, 4, sets.NewInt())
 	checkPodIdentifiers(t, c, sts, 0, 1, 2, 3)
 
 	t.Logf(fmt.Sprintf("scale to replicas %d with delete slots %v", 3, []int{0}))
-	scaleSTSWithDeletedSlots(t, pcc, sts, 3, sets.NewInt(0))
+	scaleSTSWithDeleteSlots(t, pcc, sts, 3, sets.NewInt(0))
 	checkPodIdentifiers(t, c, sts, 1, 2, 3)
 
 	// Add a template annotation change to test STS's status does update

--- a/test/integration/statefulset/util.go
+++ b/test/integration/statefulset/util.go
@@ -333,14 +333,14 @@ func scaleSTS(t *testing.T, c pcclientset.Interface, sts *appsv1alpha1.StatefulS
 	waitSTSStable(t, c, sts)
 }
 
-func scaleSTSWithDeletedSlots(t *testing.T, c pcclientset.Interface, sts *appsv1alpha1.StatefulSet, replicas int32, deletedSlots sets.Int) {
+func scaleSTSWithDeleteSlots(t *testing.T, c pcclientset.Interface, sts *appsv1alpha1.StatefulSet, replicas int32, deleteSlots sets.Int) {
 	stsClient := c.AppsV1alpha1().StatefulSets(sts.Namespace)
 	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		newSTS, err := stsClient.Get(sts.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
-		helper.SetDeletedSlots(newSTS, deletedSlots)
+		helper.SetDeleteSlots(newSTS, deleteSlots)
 		*newSTS.Spec.Replicas = replicas
 		sts, err = stsClient.Update(newSTS)
 		return err
@@ -361,7 +361,7 @@ func scaleInSTSByDeletingSlots(t *testing.T, c pcclientset.Interface, sts *appsv
 		if err != nil {
 			return err
 		}
-		helper.AddDeletedSlots(newSTS, set)
+		helper.AddDeleteSlots(newSTS, set)
 		replicas := *newSTS.Spec.Replicas - int32(set.Len())
 		if replicas < 0 {
 			t.Fatalf("replicas should not be less than 0: %v", replicas)


### PR DESCRIPTION
This reverts commit 4027666b6e7ac061cd0d5b0f5e330b99d4a4c46b.

`delete-slots` has been used in many places.