### PR TITLE
remove Desired from GetDesiredPodOrdinals

### DIFF
--- a/pkg/apis/apps/v1/helper/helper.go
+++ b/pkg/apis/apps/v1/helper/helper.go
@@ -82,8 +82,7 @@ func GetMaxReplicaCountAndDeleteSlots(replicas int32, deleteSlots sets.Int32) (i
 	return replicaCount, deleteSlots
 }
 
-// GetDesiredPodOrdinals gets desired pod ordinals of given statefulset set.
-func GetDesiredPodOrdinals(replicas int32, set metav1.Object) sets.Int32 {
+func GetPodOrdinals(replicas int32, set metav1.Object) sets.Int32 {
 	maxReplicaCount, deleteSlots := GetMaxReplicaCountAndDeleteSlots(replicas, GetDeleteSlots(set))
 	podOrdinals := sets.NewInt32()
 	for i := int32(0); i < maxReplicaCount; i++ {

--- a/pkg/apis/apps/v1/helper/helper_test.go
+++ b/pkg/apis/apps/v1/helper/helper_test.go
@@ -185,7 +185,7 @@ func int32ptr(i int32) *int32 {
 	return &i
 }
 
-func TestGetDesiredPodOrdinals(t *testing.T) {
+func TestGetPodOrdinals(t *testing.T) {
 	tests := []struct {
 		name string
 		sts  asappsv1.StatefulSet
@@ -232,7 +232,7 @@ func TestGetDesiredPodOrdinals(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetDesiredPodOrdinals(*tt.sts.Spec.Replicas, &tt.sts)
+			got := GetPodOrdinals(*tt.sts.Spec.Replicas, &tt.sts)
 			if diff := cmp.Diff(tt.want.List(), got.List()); diff != "" {
 				t.Errorf("unexpected result (-want, +got): %s", diff)
 			}


### PR DESCRIPTION
sometimes it's misleading when we compare ordinals of actual/desired
statefulsets