### PR TITLE
Add Calculate Pod Ordinal func in helper.

### DIFF
--- a/pkg/apis/apps/v1/helper/helper.go
+++ b/pkg/apis/apps/v1/helper/helper.go
@@ -123,3 +123,23 @@ func GetMinPodOrdinal(replicas int32, set metav1.Object) int32 {
 	}
 	return min
 }
+
+// CalculateScaleOutPodOrdinal calculate the expected pod ordinal before the scaling out happens,
+// if the currentReplicas is 3, and the target Replicas is 5.
+// Then the current pod ordinal list is [0,1,3], and the delete slot list is [2,4],
+// the calculated return sets would be {5,6}
+func CalculateScaleOutPodOrdinal(currentReplicas, targetReplicas int32, set metav1.Object) sets.Int32 {
+	expectedOrdinalSets := sets.Int32{}
+	if currentReplicas >= targetReplicas {
+		return expectedOrdinalSets
+	}
+	slots := GetDeleteSlots(set)
+	maxOrdinal := GetMaxPodOrdinal(currentReplicas, set)
+	for i := 1; expectedOrdinalSets.Len() < int(targetReplicas-currentReplicas); i++ {
+		expectedOrdinal := maxOrdinal + int32(i)
+		if !slots.Has(expectedOrdinal) {
+			expectedOrdinalSets.Insert(expectedOrdinal)
+		}
+	}
+	return expectedOrdinalSets
+}


### PR DESCRIPTION
This requests add a new func in helper to calculate the ordinals of the pod which would be created before scaling-out. This would be helpful for auto-scaling 

For example:

If the currentReplicas is 3, and the target Replicas is 5.
Then the current pod ordinal list is [0,1,3], and the delete slot list is [2,4], the calculated return sets would be {5,6}