### PR TITLE
print version information on startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+LDFLAGS ?= $(shell ./hack/version.sh)
+
 GO  := go
 
 ARCH ?= $(shell go env GOARCH)

--- a/cmd/controller-manager/app/app.go
+++ b/cmd/controller-manager/app/app.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/advanced-statefulset/cmd/controller-manager/options"
 	"github.com/pingcap/advanced-statefulset/pkg/controller/statefulset"
 	"github.com/pingcap/advanced-statefulset/pkg/verflag"
+	"github.com/pingcap/advanced-statefulset/pkg/version"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -34,7 +35,6 @@ import (
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/cli/globalflag"
 	"k8s.io/component-base/term"
-	"k8s.io/component-base/version"
 	"k8s.io/klog"
 )
 

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Copyright 2020 PingCAP, Inc.
+# Copyright 2023 PingCAP, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,53 +13,89 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script is used to generate version informations from git repo automatically.
-#
-# Output format:
-#
-#   <KEY1>: <VALUE1>
-#   <KEY2>: <VALUE2>
-#
-# You can simply use this command to extrac the value by key:
-#
-#   ./hack/version.sh | awk -F' ' '/^GIT_VERSION:/ {print $2}'
-#
+set -euo pipefail
 
-set -o errexit
-set -o nounset
-set -o pipefail
-
-ROOT=$(unset CDPATH && cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
-cd $ROOT
-
-GIT_EXACT_TAG=$(git describe --tags --abbrev=0 --exact-match 2>/dev/null || true)
-GIT_RECENT_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
-GIT_SHA_SHORT=$(git rev-parse --short HEAD)
-GIT_DIRTY=$(test -n "`git status --porcelain`" && echo "dirty" || echo "clean")
-
-echo "GIT_EXACT_TAG: $GIT_EXACT_TAG"
-echo "GIT_RECENT_TAG: $GIT_RECENT_TAG"
-echo "GIT_DIRTY: $GIT_DIRTY"
-echo "GIT_SHA_SHORT: $GIT_SHA_SHORT"
-
-# Modifed from k8s.io/kubernetes/hack/lib/version.sh.
-if [[ -n ${GIT_VERSION-} ]] || GIT_VERSION=$(git describe --tags --abbrev=7 HEAD 2>/dev/null); then
-    # This translates the "git describe" to an actual semver.org
-    # compatible semantic version that looks something like this:
-    #   v1.1.0-alpha.0.6+84c76d1
-    DASHES_IN_GIT_VERSION=$(echo "${GIT_VERSION}" | sed "s/[^-]//g")
-    if [[ "${DASHES_IN_GIT_VERSION}" == "---" ]] ; then
-        # We have distance to subversion (v1.1.0-subversion-1-gCommitHash)
-        GIT_VERSION=$(echo "${GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{7\}\)$/.\1\+\2/")
-    elif [[ "${DASHES_IN_GIT_VERSION}" == "--" ]] ; then
-        # We have distance to base tag (v1.1.0-1-gCommitHash)
-        GIT_VERSION=$(echo "${GIT_VERSION}" | sed "s/-g\([0-9a-f]\{7\}\)$/+\1/")
+# -----------------------------------------------------------------------------
+# Version management helpers.  These functions help to set the
+# following variables:
+#
+#    GIT_COMMIT - The git commit id corresponding to this
+#          source code.
+#    GIT_TREE_STATE - "clean" indicates no changes since the git commit id
+#        "dirty" indicates source code changes after the git commit id
+#        "archive" indicates the tree was produced by 'git archive'
+#    GIT_VERSION - "vX.Y" used to indicate the last release version.
+function advanced_statefulset::version::get_version_vars() {
+  if [[ -n ${GIT_COMMIT-} ]] || GIT_COMMIT=$(git rev-parse "HEAD^{commit}" 2>/dev/null); then
+    if [[ -z ${GIT_TREE_STATE-} ]]; then
+      # Check if the tree is dirty.  default to dirty
+      if git_status=$(git status --porcelain 2>/dev/null) && [[ -z ${git_status} ]]; then
+        GIT_TREE_STATE="clean"
+      else
+        GIT_TREE_STATE="dirty"
+      fi
     fi
-    if [[ "$GIT_DIRTY" == "dirty" ]]; then
+
+    # Use git describe to find the version based on tags.
+    if [[ -n ${GIT_VERSION-} ]] || GIT_VERSION=$(git describe --tags --abbrev=14 "${GIT_COMMIT}^{commit}" 2>/dev/null | awk -F / '{print $NF}'); then
+      # This translates the "git describe" to an actual semver.org
+      # compatible semantic version that looks something like this:
+      #   v1.0.0-beta.0.10+4c183422345d8f
+      #
+      # TODO: We continue calling this "git version" because so many
+      # downstream consumers are expecting it there.
+      DASHES_IN_VERSION=$(echo "${GIT_VERSION}" | sed "s/[^-]//g")
+      if [[ "${DASHES_IN_VERSION}" == "---" ]] ; then
+        # We have distance to subversion (v1.1.0-subversion-1-gCommitHash)
+        GIT_VERSION=$(echo "${GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{14\}\)$/.\1\+\2/")
+      elif [[ "${DASHES_IN_VERSION}" == "--" ]] ; then
+        # We have distance to base tag (v1.1.0-1-gCommitHash)
+        GIT_VERSION=$(echo "${GIT_VERSION}" | sed "s/-g\([0-9a-f]\{14\}\)$/+\1/")
+      fi
+      if [[ "${GIT_TREE_STATE}" == "dirty" ]]; then
         # git describe --dirty only considers changes to existing files, but
         # that is problematic since new untracked .go files affect the build,
         # so use our idea of "dirty" from git status instead.
         GIT_VERSION+="-dirty"
+      fi
+
+
+      # If GIT_VERSION is not a valid Semantic Version, then refuse to build.
+      if ! [[ "${GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+        echo "GIT_VERSION should be a valid Semantic Version. Current value: ${GIT_VERSION}"
+        echo "Please see more details here: https://semver.org"
+        exit 1
+      fi
     fi
-fi
-echo "GIT_VERSION: $GIT_VERSION"
+  fi
+}
+
+function advanced_statefulset::version::ldflag() {
+  local key=${1}
+  local val=${2}
+
+  echo "-X 'github.com/pingcap/advanced-statefulset/pkg/version.${key}=${val}'"
+}
+
+# Prints the value that needs to be passed to the -ldflags parameter of go build
+function advanced_statefulset::version::ldflags() {
+  advanced_statefulset::version::get_version_vars
+
+  local buildDate=
+  [[ -z ${SOURCE_DATE_EPOCH-} ]] || buildDate="--date=@${SOURCE_DATE_EPOCH}"
+  local -a ldflags=($(advanced_statefulset::version::ldflag "buildDate" "$(date ${buildDate} -u +'%Y-%m-%dT%H:%M:%SZ')"))
+  if [[ -n ${GIT_COMMIT-} ]]; then
+    ldflags+=($(advanced_statefulset::version::ldflag "gitCommit" "${GIT_COMMIT}"))
+    ldflags+=($(advanced_statefulset::version::ldflag "gitTreeState" "${GIT_TREE_STATE}"))
+  fi
+
+  if [[ -n ${GIT_VERSION-} ]]; then
+    ldflags+=($(advanced_statefulset::version::ldflag "gitVersion" "${GIT_VERSION}"))
+  fi
+
+  # The -ldflags parameter takes a single string, so join the output.
+  echo "${ldflags[*]-}"
+}
+
+# output -ldflags parameters
+advanced_statefulset::version::ldflags

--- a/pkg/verflag/verflag.go
+++ b/pkg/verflag/verflag.go
@@ -13,8 +13,6 @@
 
 // Package verflag defines utility functions to handle command line flags
 // related to version of Advanced StatefulSet.
-// This is modifed from k8s.io/component-base/version/verflag. Use it when it's
-// possible to customize version prefix.
 
 package verflag
 
@@ -25,7 +23,7 @@ import (
 
 	flag "github.com/spf13/pflag"
 
-	"k8s.io/component-base/version"
+	"github.com/pingcap/advanced-statefulset/pkg/version"
 )
 
 type versionValue int

--- a/pkg/version/type.go
+++ b/pkg/version/type.go
@@ -1,0 +1,30 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+// Info contains versioning information.
+type Info struct {
+	GitVersion   string `json:"gitVersion"`
+	GitCommit    string `json:"gitCommit"`
+	GitTreeState string `json:"gitTreeState"`
+	BuildDate    string `json:"buildDate"`
+	GoVersion    string `json:"goVersion"`
+	Compiler     string `json:"compiler"`
+	Platform     string `json:"platform"`
+}
+
+// String returns info as a human-friendly version string.
+func (info Info) String() string {
+	return info.GitVersion
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,60 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+
+	"k8s.io/klog/v2"
+)
+
+var (
+	gitVersion   = "v0.0.0-master+$Format:%h$"
+	gitCommit    = "$Format:%H$" // sha1 from git, output of $(git rev-parse HEAD)
+	gitTreeState = ""            // state of git tree, either "clean" or "dirty"
+
+	buildDate = "1970-01-01T00:00:00Z" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+)
+
+// SetVersionSuffix sets version suffix.
+func SetVersionSuffix(suffix string) {
+	gitVersion += suffix
+}
+
+// PrintVersionInfo show version info to Stdout
+func PrintVersionInfo() {
+	fmt.Printf("TiDB Operator Version: %#v\n", Get())
+}
+
+// LogVersionInfo print version info at startup
+func LogVersionInfo() {
+	klog.Info("Welcome to TiDB Operator.")
+	klog.Infof("TiDB Operator Version: %#v", Get())
+}
+
+// Get returns the overall codebase version. It's for detecting
+// what code a binary was built from.
+func Get() Info {
+	// These variables typically come from -ldflags settings and in
+	return Info{
+		GitVersion:   gitVersion,
+		GitCommit:    gitCommit,
+		GitTreeState: gitTreeState,
+		BuildDate:    buildDate,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -54,10 +54,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/component-base/logs"
-	"k8s.io/component-base/version"
 	"k8s.io/klog"
 	utilnet "k8s.io/utils/net"
 
+	"github.com/pingcap/advanced-statefulset/pkg/version"
 	e2eutil "github.com/pingcap/advanced-statefulset/test/e2e/util"
 	"github.com/pingcap/advanced-statefulset/test/third_party/k8s"
 	e2ekubectl "github.com/pingcap/advanced-statefulset/test/third_party/k8s/kubectl"


### PR DESCRIPTION
in #65, we added version information relying on the K8s Golang vendor, but as we already removed vendors, we need to add version information again.

This PR added version information as we did in TiDB Operator.

output with this PR:

`I1221 02:51:03.215852       1 app.go:54] Version: v0.6.0-1+78775ae3c81042`