### PR TITLE
Fix ASTS ControllerRevision adoption idempotency

### DIFF
--- a/pkg/controller/statefulset/stateful_set.go
+++ b/pkg/controller/statefulset/stateful_set.go
@@ -342,6 +342,10 @@ func syncLabels(kubeClient kubernetes.Interface, set *apps.StatefulSet, revision
 	for k, v := range set.Spec.Template.Labels {
 		labels[k] = v
 	}
+	// The marker is the migration-in-progress signal: ListRevisions matches
+	// revisions by it, and shouldSyncLabels re-triggers this func while it's
+	// present. Drop it once selector labels are restored so the revision stops
+	// being treated as mid-migration.
 	delete(labels, helper.UpgradeToAdvancedStatefulSetAnn)
 	revision.ObjectMeta.Labels = labels
 	return kubeClient.AppsV1().ControllerRevisions(revision.Namespace).Update(context.TODO(), revision, metav1.UpdateOptions{})
@@ -362,6 +366,9 @@ func (ssc *StatefulSetController) adoptOrphanRevisions(set *apps.StatefulSet) er
 			continue
 		}
 		if owner.UID != set.GetUID() {
+			// ListRevisions already filtered out truly-foreign owners; reaching here
+			// means this is the builtin StatefulSet being migrated. Wait for GC to
+			// orphan it before adopting.
 			continue
 		}
 		if shouldSyncLabels(revisions[i]) {

--- a/pkg/controller/statefulset/stateful_set.go
+++ b/pkg/controller/statefulset/stateful_set.go
@@ -334,6 +334,7 @@ func shouldSyncLabels(revision *kubeapps.ControllerRevision) bool {
 }
 
 func syncLabels(kubeClient kubernetes.Interface, set *apps.StatefulSet, revision *kubeapps.ControllerRevision) (*kubeapps.ControllerRevision, error) {
+	revision = revision.DeepCopy()
 	labels := revision.ObjectMeta.Labels
 	if labels == nil {
 		labels = make(map[string]string)
@@ -341,6 +342,7 @@ func syncLabels(kubeClient kubernetes.Interface, set *apps.StatefulSet, revision
 	for k, v := range set.Spec.Template.Labels {
 		labels[k] = v
 	}
+	delete(labels, helper.UpgradeToAdvancedStatefulSetAnn)
 	revision.ObjectMeta.Labels = labels
 	return kubeClient.AppsV1().ControllerRevisions(revision.Namespace).Update(context.TODO(), revision, metav1.UpdateOptions{})
 }
@@ -351,22 +353,22 @@ func (ssc *StatefulSetController) adoptOrphanRevisions(set *apps.StatefulSet) er
 	if err != nil {
 		return err
 	}
-	hasOrphans := false
+	orphanRevisions := []*kubeapps.ControllerRevision{}
+	revisionsToSyncLabels := []*kubeapps.ControllerRevision{}
 	for i := range revisions {
-		if metav1.GetControllerOf(revisions[i]) == nil {
-			hasOrphans = true
-			break
+		owner := metav1.GetControllerOf(revisions[i])
+		if owner == nil {
+			orphanRevisions = append(orphanRevisions, revisions[i])
+			continue
+		}
+		if owner.UID != set.GetUID() {
+			continue
+		}
+		if shouldSyncLabels(revisions[i]) {
+			revisionsToSyncLabels = append(revisionsToSyncLabels, revisions[i])
 		}
 	}
-	if hasOrphans {
-		for i := range revisions {
-			if shouldSyncLabels(revisions[i]) {
-				revisions[i], err = syncLabels(ssc.kubeClient, set, revisions[i])
-				if err != nil {
-					return err
-				}
-			}
-		}
+	if len(orphanRevisions) > 0 {
 		fresh, err := ssc.pcClient.AppsV1().StatefulSets(set.Namespace).Get(context.TODO(), set.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
@@ -374,7 +376,19 @@ func (ssc *StatefulSetController) adoptOrphanRevisions(set *apps.StatefulSet) er
 		if fresh.UID != set.UID {
 			return fmt.Errorf("original StatefulSet %v/%v is gone: got uid %v, wanted %v", set.Namespace, set.Name, fresh.UID, set.UID)
 		}
-		return ssc.control.AdoptOrphanRevisions(set, revisions)
+		if err := ssc.control.AdoptOrphanRevisions(set, orphanRevisions); err != nil {
+			return err
+		}
+		for i := range orphanRevisions {
+			if shouldSyncLabels(orphanRevisions[i]) {
+				revisionsToSyncLabels = append(revisionsToSyncLabels, orphanRevisions[i])
+			}
+		}
+	}
+	for i := range revisionsToSyncLabels {
+		if _, err := syncLabels(ssc.kubeClient, set, revisionsToSyncLabels[i]); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -81,6 +81,29 @@ type defaultStatefulSetControl struct {
 	recorder      record.EventRecorder
 }
 
+var builtinStatefulSetKind = kubeapps.SchemeGroupVersion.WithKind("StatefulSet")
+
+func isOrphanOrOwnedBy(revision *kubeapps.ControllerRevision, parent metav1.Object) bool {
+	owner := metav1.GetControllerOfNoCopy(revision)
+	return owner == nil || owner.UID == parent.GetUID()
+}
+
+// During migration, ControllerRevisions keep the builtin StatefulSet owner until GC orphans them.
+func isBuiltinStatefulSetUpgradeRevision(revision *kubeapps.ControllerRevision, parent metav1.Object) bool {
+	owner := metav1.GetControllerOfNoCopy(revision)
+	if owner == nil {
+		return false
+	}
+	if owner.APIVersion != builtinStatefulSetKind.GroupVersion().String() || owner.Kind != builtinStatefulSetKind.Kind || owner.Name != parent.GetName() {
+		return false
+	}
+	return revision.Labels[helper.UpgradeToAdvancedStatefulSetAnn] == parent.GetName()
+}
+
+func isUsableRevisionForSet(revision *kubeapps.ControllerRevision, parent metav1.Object) bool {
+	return isOrphanOrOwnedBy(revision, parent) || isBuiltinStatefulSetUpgradeRevision(revision, parent)
+}
+
 // UpdateStatefulSet executes the core logic loop for a stateful set, applying the predictable and
 // consistent monotonic update strategy by default - scale up proceeds in ordinal order, no new pod
 // is created while any pod is unhealthy, and pods are terminated in descending order. The burst
@@ -152,7 +175,15 @@ func (ssc *defaultStatefulSetControl) ListRevisions(set *apps.StatefulSet) ([]*k
 		return nil, err
 	}
 	res := []*kubeapps.ControllerRevision{}
+	seen := map[string]struct{}{}
 	for _, item := range append(revisions.Items, revisinsToUpgrade.Items...) {
+		if !isUsableRevisionForSet(&item, set) {
+			continue
+		}
+		if _, ok := seen[item.Name]; ok {
+			continue
+		}
+		seen[item.Name] = struct{}{}
 		local := item
 		res = append(res, &local)
 	}
@@ -163,6 +194,12 @@ func (ssc *defaultStatefulSetControl) AdoptOrphanRevisions(
 	set *apps.StatefulSet,
 	revisions []*kubeapps.ControllerRevision) error {
 	for i := range revisions {
+		if owner := metav1.GetControllerOfNoCopy(revisions[i]); owner != nil {
+			if owner.UID == set.GetUID() {
+				continue
+			}
+			return fmt.Errorf("attempt to adopt revision owned by %v", owner)
+		}
 		adopted, err := ssc.adoptControllerRevision(set, controllerKind, revisions[i])
 		if err != nil {
 			return err
@@ -191,6 +228,9 @@ func (ssc *defaultStatefulSetControl) truncateHistory(
 	}
 	// collect live revisions and historic revisions
 	for i := range revisions {
+		if isBuiltinStatefulSetUpgradeRevision(revisions[i], set) {
+			continue
+		}
 		if !live[revisions[i].Name] {
 			history = append(history, revisions[i])
 		}
@@ -247,11 +287,15 @@ func (ssc *defaultStatefulSetControl) getStatefulSetRevisions(
 	} else if equalCount > 0 {
 		// if the equivalent revision is not immediately prior we will roll back by incrementing the
 		// Revision of the equivalent revision
-		updateRevision, err = ssc.updateControllerRevision(
-			equalRevisions[equalCount-1],
-			updateRevision.Revision)
-		if err != nil {
-			return nil, nil, collisionCount, err
+		newRevision := updateRevision.Revision
+		updateRevision = equalRevisions[equalCount-1]
+		if !isBuiltinStatefulSetUpgradeRevision(updateRevision, set) {
+			updateRevision, err = ssc.updateControllerRevision(
+				updateRevision,
+				newRevision)
+			if err != nil {
+				return nil, nil, collisionCount, err
+			}
 		}
 	} else {
 		//if there is no equivalent revision we create a new one
@@ -704,7 +748,7 @@ func (ssc *defaultStatefulSetControl) createControllerRevision(parent metav1.Obj
 			if err != nil {
 				return nil, err
 			}
-			if bytes.Equal(exists.Data.Raw, clone.Data.Raw) {
+			if bytes.Equal(exists.Data.Raw, clone.Data.Raw) && isUsableRevisionForSet(exists, parent) {
 				return exists, nil
 			}
 			*collisionCount++

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -196,7 +196,7 @@ func (ssc *defaultStatefulSetControl) AdoptOrphanRevisions(
 	for i := range revisions {
 		if owner := metav1.GetControllerOfNoCopy(revisions[i]); owner != nil {
 			if owner.UID == set.GetUID() {
-				continue
+				continue // already adopted by a prior partial reconcile; nothing to do
 			}
 			return fmt.Errorf("attempt to adopt revision owned by %v", owner)
 		}
@@ -228,6 +228,9 @@ func (ssc *defaultStatefulSetControl) truncateHistory(
 	}
 	// collect live revisions and historic revisions
 	for i := range revisions {
+		// Not ours to delete yet: still owned by the builtin StatefulSet being
+		// migrated. Deleting it here could break currentRevision resolution before
+		// GC orphans it and we adopt it.
 		if isBuiltinStatefulSetUpgradeRevision(revisions[i], set) {
 			continue
 		}
@@ -289,6 +292,9 @@ func (ssc *defaultStatefulSetControl) getStatefulSetRevisions(
 		// Revision of the equivalent revision
 		newRevision := updateRevision.Revision
 		updateRevision = equalRevisions[equalCount-1]
+		// Skip bumping the Revision of a revision we don't own yet; writing to an
+		// object still controlled by the builtin StatefulSet would race with
+		// migration. It gets corrected once GC orphans it and we adopt it.
 		if !isBuiltinStatefulSetUpgradeRevision(updateRevision, set) {
 			updateRevision, err = ssc.updateControllerRevision(
 				updateRevision,
@@ -748,6 +754,9 @@ func (ssc *defaultStatefulSetControl) createControllerRevision(parent metav1.Obj
 			if err != nil {
 				return nil, err
 			}
+			// A data-equal revision owned by a foreign controller (outside an
+			// in-progress migration) must not be reused, or we'd silently borrow
+			// someone else's history entry.
 			if bytes.Equal(exists.Data.Raw, clone.Data.Raw) && isUsableRevisionForSet(exists, parent) {
 				return exists, nil
 			}

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package statefulset
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -42,6 +43,7 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	apps "github.com/pingcap/advanced-statefulset/client/apis/apps/v1"
+	"github.com/pingcap/advanced-statefulset/client/apis/apps/v1/helper"
 	clientset "github.com/pingcap/advanced-statefulset/client/client/clientset/versioned"
 	pcfake "github.com/pingcap/advanced-statefulset/client/client/clientset/versioned/fake"
 	pcinformers "github.com/pingcap/advanced-statefulset/client/client/informers/externalversions"
@@ -632,6 +634,170 @@ func TestStatefulSetControl_getSetRevisions(t *testing.T) {
 	}
 	for i := range tests {
 		testFn(&tests[i], t)
+	}
+}
+
+func TestStatefulSetControlListRevisionsDedupesUpgradeRevision(t *testing.T) {
+	set := newStatefulSet(3)
+	set.UID = "set-uid"
+	set.Status.CollisionCount = new(int32)
+
+	revision := newRevisionOrDie(set, 1)
+	if revision.Labels == nil {
+		revision.Labels = map[string]string{}
+	}
+	revision.Labels[helper.UpgradeToAdvancedStatefulSetAnn] = set.Name
+
+	kubeClient := fake.NewSimpleClientset(revision)
+	ssc := defaultStatefulSetControl{csAppsV1: kubeClient.AppsV1()}
+
+	revisions, err := ssc.ListRevisions(set)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(revisions) != 1 {
+		t.Fatalf("expected one deduped revision, got %d", len(revisions))
+	}
+	if revisions[0].Name != revision.Name {
+		t.Fatalf("expected revision %s, got %s", revision.Name, revisions[0].Name)
+	}
+}
+
+func TestStatefulSetControlListRevisionsSkipsDifferentOwnerUpgradeRevision(t *testing.T) {
+	set := newStatefulSet(3)
+	set.UID = "set-uid"
+	set.Status.CollisionCount = new(int32)
+
+	revision := newRevisionOrDie(set, 1)
+	revision.OwnerReferences[0].UID = "other-uid"
+	markRevisionForUpgrade(set, revision)
+
+	kubeClient := fake.NewSimpleClientset(revision)
+	ssc := defaultStatefulSetControl{csAppsV1: kubeClient.AppsV1()}
+
+	revisions, err := ssc.ListRevisions(set)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(revisions) != 0 {
+		t.Fatalf("expected different-owner upgrade revision to be filtered, got %d revisions", len(revisions))
+	}
+}
+
+func TestStatefulSetControlListRevisionsIncludesBuiltinOwnerUpgradeRevision(t *testing.T) {
+	set := newStatefulSet(3)
+	set.UID = "set-uid"
+	set.Status.CollisionCount = new(int32)
+
+	revision := newRevisionOrDie(set, 1)
+	revision.OwnerReferences[0].APIVersion = kubeapps.SchemeGroupVersion.String()
+	revision.OwnerReferences[0].UID = "native-sts-uid"
+	markRevisionForUpgrade(set, revision)
+
+	kubeClient := fake.NewSimpleClientset(revision)
+	ssc := defaultStatefulSetControl{csAppsV1: kubeClient.AppsV1()}
+
+	revisions, err := ssc.ListRevisions(set)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(revisions) != 1 {
+		t.Fatalf("expected builtin-owner upgrade revision to be included, got %d revisions", len(revisions))
+	}
+	if revisions[0].Name != revision.Name {
+		t.Fatalf("expected revision %s, got %s", revision.Name, revisions[0].Name)
+	}
+}
+
+func TestStatefulSetControlRollbackDoesNotBumpBuiltinOwnerUpgradeRevision(t *testing.T) {
+	set := newStatefulSet(3)
+	set.UID = "set-uid"
+	set.Status.CollisionCount = new(int32)
+
+	rollbackRevision := newRevisionOrDie(set, 1)
+	rollbackRevision.OwnerReferences[0].APIVersion = kubeapps.SchemeGroupVersion.String()
+	rollbackRevision.OwnerReferences[0].UID = "native-sts-uid"
+	markRevisionForUpgrade(set, rollbackRevision)
+
+	newerSet := set.DeepCopy()
+	newerSet.Spec.Template.Spec.Containers[0].Image = "newer"
+	newerRevision := newRevisionOrDie(newerSet, 2)
+	newerRevision.OwnerReferences[0].APIVersion = kubeapps.SchemeGroupVersion.String()
+	newerRevision.OwnerReferences[0].UID = "native-sts-uid"
+	markRevisionForUpgrade(set, newerRevision)
+
+	kubeClient := fake.NewSimpleClientset(rollbackRevision, newerRevision)
+	ssc := defaultStatefulSetControl{csAppsV1: kubeClient.AppsV1()}
+
+	revisions, err := ssc.ListRevisions(set)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, updateRevision, _, err := ssc.getStatefulSetRevisions(set, revisions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updateRevision.Name != rollbackRevision.Name {
+		t.Fatalf("expected rollback to use revision %s, got %s", rollbackRevision.Name, updateRevision.Name)
+	}
+
+	got, err := kubeClient.AppsV1().ControllerRevisions(set.Namespace).Get(context.TODO(), rollbackRevision.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Revision != rollbackRevision.Revision {
+		t.Fatalf("expected builtin-owned rollback revision number to remain %d, got %d", rollbackRevision.Revision, got.Revision)
+	}
+}
+
+func TestStatefulSetControlAdoptOrphanRevisionsSkipsAlreadyOwned(t *testing.T) {
+	set := newStatefulSet(3)
+	set.UID = "set-uid"
+	set.Status.CollisionCount = new(int32)
+
+	owned := newRevisionOrDie(set, 1)
+	orphanSet := set.DeepCopy()
+	orphanSet.Spec.Template.Spec.Containers[0].Image = "orphan"
+	orphan := newRevisionOrDie(orphanSet, 2)
+	orphan.OwnerReferences = nil
+
+	kubeClient := fake.NewSimpleClientset(owned, orphan)
+	ssc := defaultStatefulSetControl{csAppsV1: kubeClient.AppsV1()}
+
+	if err := ssc.AdoptOrphanRevisions(set, []*kubeapps.ControllerRevision{owned, orphan}); err != nil {
+		t.Fatalf("AdoptOrphanRevisions() error: %v", err)
+	}
+
+	adopted, err := kubeClient.AppsV1().ControllerRevisions(set.Namespace).Get(context.TODO(), orphan.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	owner := metav1.GetControllerOf(adopted)
+	if owner == nil {
+		t.Fatal("expected orphan revision to be adopted")
+	}
+	if owner.UID != set.UID {
+		t.Fatalf("expected owner UID %s, got %s", set.UID, owner.UID)
+	}
+}
+
+func TestStatefulSetControlAdoptOrphanRevisionsRejectsDifferentOwner(t *testing.T) {
+	set := newStatefulSet(3)
+	set.UID = "set-uid"
+	set.Status.CollisionCount = new(int32)
+
+	revision := newRevisionOrDie(set, 1)
+	revision.OwnerReferences[0].UID = "other-uid"
+
+	kubeClient := fake.NewSimpleClientset(revision)
+	ssc := defaultStatefulSetControl{csAppsV1: kubeClient.AppsV1()}
+
+	err := ssc.AdoptOrphanRevisions(set, []*kubeapps.ControllerRevision{revision})
+	if err == nil {
+		t.Fatal("expected different owner to be rejected")
+	}
+	if !strings.Contains(err.Error(), "attempt to adopt revision owned by") {
+		t.Fatalf("expected owner conflict error, got %v", err)
 	}
 }
 
@@ -2165,5 +2331,30 @@ func newRevisionOrDie(set *apps.StatefulSet, revision int64) *kubeapps.Controlle
 	if err != nil {
 		panic(err)
 	}
+	rev.Namespace = set.Namespace
 	return rev
+}
+
+func markRevisionForUpgrade(set *apps.StatefulSet, revision *kubeapps.ControllerRevision) {
+	if revision.Labels == nil {
+		revision.Labels = map[string]string{}
+	}
+	for k := range set.Spec.Selector.MatchLabels {
+		delete(revision.Labels, k)
+	}
+	revision.Labels[helper.UpgradeToAdvancedStatefulSetAnn] = set.Name
+}
+
+func revisionHasUpgradeMarker(revision *kubeapps.ControllerRevision) bool {
+	_, ok := revision.Labels[helper.UpgradeToAdvancedStatefulSetAnn]
+	return ok
+}
+
+func assertRevisionSelectorLabels(t *testing.T, set *apps.StatefulSet, revision *kubeapps.ControllerRevision) {
+	t.Helper()
+	for k, v := range set.Spec.Template.Labels {
+		if revision.Labels[k] != v {
+			t.Fatalf("expected revision %s label %s=%s, got %s", revision.Name, k, v, revision.Labels[k])
+		}
+	}
 }

--- a/pkg/controller/statefulset/stateful_set_test.go
+++ b/pkg/controller/statefulset/stateful_set_test.go
@@ -17,12 +17,14 @@ limitations under the License.
 package statefulset
 
 import (
+	"context"
 	"sort"
 	"testing"
 
 	apps "github.com/pingcap/advanced-statefulset/client/apis/apps/v1"
 	"github.com/pingcap/advanced-statefulset/client/client/clientset/versioned/fake"
 	informers "github.com/pingcap/advanced-statefulset/client/client/informers/externalversions"
+	kubeapps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -48,6 +50,321 @@ func TestStatefulSetControllerCreates(t *testing.T) {
 	}
 	if set.Status.Replicas != 3 {
 		t.Errorf("set.Status.Replicas = %v; want 3", set.Status.Replicas)
+	}
+}
+
+func TestStatefulSetControllerAdoptOrphanRevisionsSyncsUpgradeLabels(t *testing.T) {
+	set := newStatefulSet(3)
+	set.UID = "set-uid"
+	set.Status.CollisionCount = new(int32)
+
+	owned := newRevisionOrDie(set, 1)
+	markRevisionForUpgrade(set, owned)
+
+	orphanSet := set.DeepCopy()
+	orphanSet.Spec.Template.Spec.Containers[0].Image = "orphan"
+	orphan := newRevisionOrDie(orphanSet, 2)
+	orphan.OwnerReferences = nil
+	markRevisionForUpgrade(set, orphan)
+
+	ssc, _ := newFakeStatefulSetController(set, owned, orphan)
+	if err := ssc.adoptOrphanRevisions(set); err != nil {
+		t.Fatalf("adoptOrphanRevisions() error: %v", err)
+	}
+
+	for _, revision := range []*kubeapps.ControllerRevision{owned, orphan} {
+		got, err := ssc.kubeClient.AppsV1().ControllerRevisions(set.Namespace).Get(context.TODO(), revision.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertRevisionSelectorLabels(t, set, got)
+		if revisionHasUpgradeMarker(got) {
+			t.Fatalf("expected upgrade marker to be removed from revision %s", got.Name)
+		}
+	}
+
+	adopted, err := ssc.kubeClient.AppsV1().ControllerRevisions(set.Namespace).Get(context.TODO(), orphan.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	owner := metav1.GetControllerOf(adopted)
+	if owner == nil {
+		t.Fatal("expected orphan revision to be adopted")
+	}
+	if owner.UID != set.UID {
+		t.Fatalf("expected owner UID %s, got %s", set.UID, owner.UID)
+	}
+}
+
+func TestStatefulSetControllerAdoptOrphanRevisionsSyncsUpgradeLabelsWithoutOrphans(t *testing.T) {
+	set := newStatefulSet(3)
+	set.UID = "set-uid"
+	set.Status.CollisionCount = new(int32)
+
+	owned := newRevisionOrDie(set, 1)
+	markRevisionForUpgrade(set, owned)
+
+	ssc, _ := newFakeStatefulSetController(set, owned)
+	if err := ssc.adoptOrphanRevisions(set); err != nil {
+		t.Fatalf("adoptOrphanRevisions() error: %v", err)
+	}
+
+	got, err := ssc.kubeClient.AppsV1().ControllerRevisions(set.Namespace).Get(context.TODO(), owned.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertRevisionSelectorLabels(t, set, got)
+	if revisionHasUpgradeMarker(got) {
+		t.Fatalf("expected upgrade marker to be removed from revision %s", got.Name)
+	}
+	owner := metav1.GetControllerOf(got)
+	if owner == nil {
+		t.Fatal("expected revision owner to remain")
+	}
+	if owner.UID != set.UID {
+		t.Fatalf("expected owner UID %s, got %s", set.UID, owner.UID)
+	}
+}
+
+func TestStatefulSetControllerAdoptOrphanRevisionsSkipsDifferentOwnerUpgradeLabels(t *testing.T) {
+	set := newStatefulSet(3)
+	set.UID = "set-uid"
+	set.Status.CollisionCount = new(int32)
+
+	revision := newRevisionOrDie(set, 1)
+	revision.OwnerReferences[0].UID = "other-uid"
+	markRevisionForUpgrade(set, revision)
+
+	ssc, _ := newFakeStatefulSetController(set, revision)
+	if err := ssc.adoptOrphanRevisions(set); err != nil {
+		t.Fatalf("adoptOrphanRevisions() error: %v", err)
+	}
+
+	got, err := ssc.kubeClient.AppsV1().ControllerRevisions(set.Namespace).Get(context.TODO(), revision.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !revisionHasUpgradeMarker(got) {
+		t.Fatalf("expected upgrade marker to remain on revision %s", got.Name)
+	}
+	for k := range set.Spec.Selector.MatchLabels {
+		if _, ok := got.Labels[k]; ok {
+			t.Fatalf("expected selector label %s to remain absent on revision %s", k, got.Name)
+		}
+	}
+	owner := metav1.GetControllerOf(got)
+	if owner == nil {
+		t.Fatal("expected revision owner to remain")
+	}
+	if owner.UID != "other-uid" {
+		t.Fatalf("expected owner UID %s, got %s", "other-uid", owner.UID)
+	}
+}
+
+func TestStatefulSetControllerAdoptOrphanRevisionsSyncsOnlyAdoptableUpgradeLabels(t *testing.T) {
+	set := newStatefulSet(3)
+	set.UID = "set-uid"
+	set.Status.CollisionCount = new(int32)
+
+	otherOwned := newRevisionOrDie(set, 1)
+	otherOwned.OwnerReferences[0].UID = "other-uid"
+	markRevisionForUpgrade(set, otherOwned)
+
+	orphanSet := set.DeepCopy()
+	orphanSet.Spec.Template.Spec.Containers[0].Image = "orphan"
+	orphan := newRevisionOrDie(orphanSet, 2)
+	orphan.OwnerReferences = nil
+	markRevisionForUpgrade(set, orphan)
+
+	ssc, _ := newFakeStatefulSetController(set, otherOwned, orphan)
+	if err := ssc.adoptOrphanRevisions(set); err != nil {
+		t.Fatalf("adoptOrphanRevisions() error: %v", err)
+	}
+
+	gotOrphan, err := ssc.kubeClient.AppsV1().ControllerRevisions(set.Namespace).Get(context.TODO(), orphan.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertRevisionSelectorLabels(t, set, gotOrphan)
+	if revisionHasUpgradeMarker(gotOrphan) {
+		t.Fatalf("expected upgrade marker to be removed from revision %s", gotOrphan.Name)
+	}
+	orphanOwner := metav1.GetControllerOf(gotOrphan)
+	if orphanOwner == nil {
+		t.Fatal("expected orphan revision to be adopted")
+	}
+	if orphanOwner.UID != set.UID {
+		t.Fatalf("expected owner UID %s, got %s", set.UID, orphanOwner.UID)
+	}
+
+	gotOther, err := ssc.kubeClient.AppsV1().ControllerRevisions(set.Namespace).Get(context.TODO(), otherOwned.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !revisionHasUpgradeMarker(gotOther) {
+		t.Fatalf("expected upgrade marker to remain on revision %s", gotOther.Name)
+	}
+	for k := range set.Spec.Selector.MatchLabels {
+		if _, ok := gotOther.Labels[k]; ok {
+			t.Fatalf("expected selector label %s to remain absent on revision %s", k, gotOther.Name)
+		}
+	}
+	otherOwner := metav1.GetControllerOf(gotOther)
+	if otherOwner == nil {
+		t.Fatal("expected different owner to remain")
+	}
+	if otherOwner.UID != "other-uid" {
+		t.Fatalf("expected owner UID %s, got %s", "other-uid", otherOwner.UID)
+	}
+}
+
+func TestStatefulSetControllerSyncIgnoresDifferentOwnerUpgradeRevisions(t *testing.T) {
+	set := newStatefulSet(0)
+	set.UID = "set-uid"
+	set.Status.CollisionCount = new(int32)
+	historyLimit := int32(0)
+	set.Spec.RevisionHistoryLimit = &historyLimit
+
+	sameData := newRevisionOrDie(set, 7)
+	sameData.OwnerReferences[0].UID = "other-uid"
+	markRevisionForUpgrade(set, sameData)
+
+	differentDataSet := set.DeepCopy()
+	differentDataSet.Spec.Template.Spec.Containers[0].Image = "foreign"
+	differentData := newRevisionOrDie(differentDataSet, 8)
+	differentData.OwnerReferences[0].UID = "other-uid"
+	markRevisionForUpgrade(set, differentData)
+
+	ssc, spc := newFakeStatefulSetController(set, sameData, differentData)
+	if err := spc.setsIndexer.Add(set); err != nil {
+		t.Fatal(err)
+	}
+
+	key, err := cache.MetaNamespaceKeyFunc(set)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ssc.sync(key); err != nil {
+		t.Fatalf("sync() error: %v", err)
+	}
+
+	gotSet, err := spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotSet.Status.CurrentRevision == "" || gotSet.Status.UpdateRevision == "" {
+		t.Fatalf("expected sync to set current/update revisions, got current=%s update=%s",
+			gotSet.Status.CurrentRevision, gotSet.Status.UpdateRevision)
+	}
+	if gotSet.Status.CurrentRevision == sameData.Name || gotSet.Status.UpdateRevision == sameData.Name {
+		t.Fatalf("expected same-data foreign revision %s not to be current/update, got current=%s update=%s",
+			sameData.Name, gotSet.Status.CurrentRevision, gotSet.Status.UpdateRevision)
+	}
+	if gotSet.Status.CurrentRevision == differentData.Name || gotSet.Status.UpdateRevision == differentData.Name {
+		t.Fatalf("expected different-data foreign revision %s not to be current/update, got current=%s update=%s",
+			differentData.Name, gotSet.Status.CurrentRevision, gotSet.Status.UpdateRevision)
+	}
+
+	for _, revision := range []*kubeapps.ControllerRevision{sameData, differentData} {
+		got, err := ssc.kubeClient.AppsV1().ControllerRevisions(set.Namespace).Get(context.TODO(), revision.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected foreign revision %s to remain: %v", revision.Name, err)
+		}
+		if !revisionHasUpgradeMarker(got) {
+			t.Fatalf("expected upgrade marker to remain on revision %s", got.Name)
+		}
+		for k := range set.Spec.Selector.MatchLabels {
+			if _, ok := got.Labels[k]; ok {
+				t.Fatalf("expected selector label %s to remain absent on revision %s", k, got.Name)
+			}
+		}
+		owner := metav1.GetControllerOf(got)
+		if owner == nil {
+			t.Fatalf("expected foreign owner to remain on revision %s", got.Name)
+		}
+		if owner.UID != "other-uid" {
+			t.Fatalf("expected owner UID %s, got %s", "other-uid", owner.UID)
+		}
+	}
+}
+
+func TestStatefulSetControllerSyncPreservesBuiltinOwnerUpgradeRevision(t *testing.T) {
+	set := newStatefulSet(1)
+	set.UID = "set-uid"
+	set.Status.CollisionCount = new(int32)
+	historyLimit := int32(0)
+	set.Spec.RevisionHistoryLimit = &historyLimit
+
+	revision := newRevisionOrDie(set, 1)
+	revision.OwnerReferences[0].APIVersion = kubeapps.SchemeGroupVersion.String()
+	revision.OwnerReferences[0].UID = "native-sts-uid"
+	markRevisionForUpgrade(set, revision)
+	set.Status.CurrentRevision = revision.Name
+	set.Status.UpdateRevision = revision.Name
+
+	historySet := set.DeepCopy()
+	historySet.Spec.Template.Spec.Containers[0].Image = "history"
+	historyRevision := newRevisionOrDie(historySet, 0)
+	historyRevision.OwnerReferences[0].APIVersion = kubeapps.SchemeGroupVersion.String()
+	historyRevision.OwnerReferences[0].UID = "native-sts-uid"
+	markRevisionForUpgrade(set, historyRevision)
+
+	pod := newStatefulSetPod(set, 0)
+	pod.Status.Phase = v1.PodRunning
+	setPodRevision(pod, revision.Name)
+
+	ssc, spc := newFakeStatefulSetController(set, revision, historyRevision)
+	if err := spc.setsIndexer.Add(set); err != nil {
+		t.Fatal(err)
+	}
+	if err := spc.podsIndexer.Add(pod); err != nil {
+		t.Fatal(err)
+	}
+
+	key, err := cache.MetaNamespaceKeyFunc(set)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ssc.sync(key); err != nil {
+		t.Fatalf("sync() error: %v", err)
+	}
+
+	gotSet, err := spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotSet.Status.CurrentRevision != revision.Name || gotSet.Status.UpdateRevision != revision.Name {
+		t.Fatalf("expected migrated revision %s to stay current/update, got current=%s update=%s",
+			revision.Name, gotSet.Status.CurrentRevision, gotSet.Status.UpdateRevision)
+	}
+	if gotSet.Status.CurrentReplicas != 1 || gotSet.Status.UpdatedReplicas != 1 {
+		t.Fatalf("expected existing pod revision to stay current/updated, got current=%d updated=%d",
+			gotSet.Status.CurrentReplicas, gotSet.Status.UpdatedReplicas)
+	}
+	if gotSet.Status.CollisionCount == nil || *gotSet.Status.CollisionCount != 0 {
+		t.Fatalf("expected collision count to remain 0, got %v", gotSet.Status.CollisionCount)
+	}
+
+	for _, wantRevision := range []*kubeapps.ControllerRevision{revision, historyRevision} {
+		gotRevision, err := ssc.kubeClient.AppsV1().ControllerRevisions(set.Namespace).Get(context.TODO(), wantRevision.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected builtin-owned revision %s to remain: %v", wantRevision.Name, err)
+		}
+		if !revisionHasUpgradeMarker(gotRevision) {
+			t.Fatalf("expected upgrade marker to remain on revision %s until it is orphaned", gotRevision.Name)
+		}
+		for k := range set.Spec.Selector.MatchLabels {
+			if _, ok := gotRevision.Labels[k]; ok {
+				t.Fatalf("expected selector label %s to remain absent on revision %s until it is orphaned", k, gotRevision.Name)
+			}
+		}
+		owner := metav1.GetControllerOf(gotRevision)
+		if owner == nil {
+			t.Fatalf("expected builtin StatefulSet owner to remain on revision %s", gotRevision.Name)
+		}
+		if owner.APIVersion != kubeapps.SchemeGroupVersion.String() || owner.UID != "native-sts-uid" {
+			t.Fatalf("expected builtin StatefulSet owner to remain on revision %s, got %v", gotRevision.Name, owner)
+		}
 	}
 }
 

--- a/test/e2e/apps/asv1.go
+++ b/test/e2e/apps/asv1.go
@@ -473,11 +473,50 @@ var _ = SIGDescribe("Advanced StatefulSet [v1]", func() {
 			ginkgo.By("Wait for all pods are running and ready")
 			e2esset.WaitForRunningAndReady(c, *ss.Spec.Replicas, ss)
 
+			// Roll the builtin StatefulSet once so migration must preserve more than one
+			// ControllerRevision (history + current), exercising adoption with real history.
+			newImage := NewWebserverImage
+			oldImage := ss.Spec.Template.Spec.Containers[0].Image
+			k8s.ExpectNotEqual(oldImage, newImage, "Incorrect test setup: should update to a different image")
+			ginkgo.By(fmt.Sprintf("Rolling update image from %s to %s to build revision history", oldImage, newImage))
+			ss, err = updateStatefulSetWithRetries(c, ns, ss.Name, func(update *appsv1.StatefulSet) {
+				update.Spec.Template.Spec.Containers[0].Image = newImage
+			})
+			k8s.ExpectNoError(err)
+			ginkgo.By("Wait for the rolling update to complete")
+			e2esset.WaitForState(c, ss, func(set *appsv1.StatefulSet, pods *v1.PodList) (bool, error) {
+				if set.Status.CurrentRevision != set.Status.UpdateRevision {
+					return false, nil
+				}
+				if set.Status.ReadyReplicas != *set.Spec.Replicas {
+					return false, nil
+				}
+				if len(pods.Items) != int(*set.Spec.Replicas) {
+					return false, nil
+				}
+				for i := range pods.Items {
+					if pods.Items[i].Spec.Containers[0].Image != newImage {
+						return false, nil
+					}
+				}
+				return true, nil
+			})
+			ss = waitForStatus(c, ss)
+
 			selector, err := metav1.LabelSelectorAsSelector(ss.Spec.Selector)
 			k8s.ExpectNoError(err)
 			revisionListOptions := metav1.ListOptions{LabelSelector: selector.String()}
 			oldRevisionList, err := c.AppsV1().ControllerRevisions(ns).List(context.TODO(), revisionListOptions)
 			k8s.ExpectNoError(err)
+			gomega.Expect(len(oldRevisionList.Items)).To(gomega.BeNumerically(">=", 2), "expected revision history (>= 2 revisions) before migration")
+
+			// Record pod identities so we can assert the migration is seamless (no restart).
+			podsBeforeUpgrade := e2esset.GetPodList(c, ss)
+			gomega.Expect(podsBeforeUpgrade.Items).To(gomega.HaveLen(int(*ss.Spec.Replicas)))
+			uidBeforeUpgrade := map[string]string{}
+			for i := range podsBeforeUpgrade.Items {
+				uidBeforeUpgrade[podsBeforeUpgrade.Items[i].Name] = string(podsBeforeUpgrade.Items[i].UID)
+			}
 
 			ginkgo.By(fmt.Sprintf("Upgrading the builtin StatefulSet %s/%s", ss.Namespace, ss.Name))
 			ss, err = c.AppsV1().StatefulSets(ns).Get(context.TODO(), ss.Name, metav1.GetOptions{})
@@ -526,6 +565,26 @@ var _ = SIGDescribe("Advanced StatefulSet [v1]", func() {
 				return true, nil
 			})
 			k8s.ExpectNoError(err)
+
+			// The migration must be seamless: existing pods keep their identity (no restart).
+			ginkgo.By("Verifying that the migration did not restart any pod")
+			gomega.Consistently(func() error {
+				podList := e2esset.GetPodList(c, ss)
+				if len(podList.Items) != int(*ss.Spec.Replicas) {
+					return fmt.Errorf("expected %d pods, got %d", int(*ss.Spec.Replicas), len(podList.Items))
+				}
+				for i := range podList.Items {
+					name := podList.Items[i].Name
+					want, ok := uidBeforeUpgrade[name]
+					if !ok {
+						return fmt.Errorf("unexpected pod %s appeared after migration", name)
+					}
+					if string(podList.Items[i].UID) != want {
+						return fmt.Errorf("pod %s was recreated during migration: uid %s != %s", name, podList.Items[i].UID, want)
+					}
+				}
+				return nil
+			}, 30*time.Second, 3*time.Second).Should(gomega.Succeed())
 		})
 	})
 


### PR DESCRIPTION
## Summary

- Make ControllerRevision adoption idempotent during native StatefulSet to AdvancedStatefulSet migration.
- Keep revisions still owned by the builtin StatefulSet being migrated visible and reusable (instead of forking duplicate revisions) until GC orphans them.
- Deduplicate revisions that match both the StatefulSet selector and the upgrade marker, and filter out revisions owned by a foreign controller.
- Remove the upgrade marker after restoring selector labels so migrated revisions are not repeatedly processed.
- Add unit coverage for mixed owned/orphan revisions, conflicting ownership, builtin-owner migration revisions, and rollback handling; extend the migration e2e to assert revision history is preserved and pods are not restarted.

## Why

During ASTS migration, a reconcile can partially adopt ControllerRevisions and then retry while some revisions are already owned by the same AdvancedStatefulSet and others still carry `apps.pingcap.com/upgrade-to-asts`. The previous adoption path tried to adopt every listed revision again, so it failed with `attempt to adopt revision owned by ...` and could leave the StatefulSet status/scale path stuck.

A stricter owner filter alone is not enough: while the builtin StatefulSet is being deleted with `DeletePropagationOrphan`, its ControllerRevisions keep the builtin owner until GC strips it. Hiding those revisions during that window would make the controller fork duplicate revisions and collapse `currentRevision`/`updateRevision`, causing a spurious rolling update of an otherwise seamless migration.

## How

- `isUsableRevisionForSet` treats a revision as usable when it is orphaned, already owned by this set, or still owned by the builtin StatefulSet being migrated (`apps/v1` StatefulSet owner with our upgrade marker and matching name).
- `ListRevisions` lists by selector and by upgrade marker, returns each revision once, and drops revisions owned by a foreign controller.
- `AdoptOrphanRevisions` skips revisions already owned by the same StatefulSet UID, adopts only orphan revisions, and still rejects revisions owned by another controller.
- `createControllerRevision` only reuses a data-equal existing revision when it is usable by this set, avoiding duplicate revisions during migration.
- `truncateHistory` keeps builtin migration revisions until GC orphans them; `getStatefulSetRevisions` does not bump the `Revision` of a builtin-owned migration revision on rollback.
- `syncLabels` deep-copies the revision, restores selector labels from the pod template, and removes the migration marker; it runs only for orphaned or already-owned revisions.

## Testing

- [x] `git diff --check`
- [x] `go test ./pkg/controller/statefulset`
- [x] Local kind e2e on PR head `4e0ec26721e7`:
  - `GINKGO_NO_COLOR=y KUBE_VERSION=v1.28 KUBE_WORKERS=1 ./hack/e2e.sh`
  - `Ran 16 of 21 Specs in 987.017 seconds`
  - `SUCCESS! -- 16 Passed | 0 Failed | 0 Pending | 5 Skipped`
  - `Test Suite Passed`

## Risks and Reviewer Focus

- Review the adoption semantics around owner UID matching and the builtin-owner escape hatch. Same-owner revisions are treated as already adopted; foreign revisions are filtered/rejected; builtin StatefulSet migration revisions stay usable until GC orphans them.
- This branch is based on the `v0.7.0` tag for a patch-release style fix, while the PR targets `master`. `git merge-tree` did not show conflict markers when merging into current `master`.
